### PR TITLE
bug-fix: correct error code for tag disable validation check

### DIFF
--- a/app/ext/datastore/ruleengine.go
+++ b/app/ext/datastore/ruleengine.go
@@ -313,7 +313,7 @@ func DisableTag(ctx context.Context, ruleEngineName string, tag string) *entitie
 		}
 
 		if existingEngine.DefaultTag == tag {
-			return nil, entities.NewError(entities.ErrCodeDatastoreFailed)
+			return nil, entities.NewError(entities.ErrCodeTagDisableNotAllowed)
 		}
 
 		existingEngine.LastUpdateTime = time.Now().Unix()


### PR DESCRIPTION
* Tag disable is not allowed if tag is set as default. For this check it was returning ErrCodeDatastoreFailed, instead it should return error code-ErrCodeTagDisableNotAllowed. This change fixes the same.